### PR TITLE
fix: switch to tab view only when more than one tabs are available

### DIFF
--- a/src/components/program/ProgramPage.jsx
+++ b/src/components/program/ProgramPage.jsx
@@ -42,12 +42,13 @@ class ProgramPage extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { enrolledPrograms, tabViewEnabled } = this.props;
+    const { enrolledPrograms, tabViewEnabled, programDiscussions } = this.props;
     if (enrolledPrograms && enrolledPrograms !== prevProps.enrolledPrograms) {
       this.validateProgramAccess(enrolledPrograms);
     }
     if (tabViewEnabled && tabViewEnabled !== prevProps.tabViewEnabled) {
-      this.switchView(tabViewEnabled);
+      const switchTabView = programDiscussions.configured && tabViewEnabled;
+      this.switchView(switchTabView);
     }
   }
 

--- a/src/components/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
+++ b/src/components/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
@@ -395,7 +395,7 @@ exports[`ProgramListPage correctly renders the loading page 1`] = `
         </ul>
         <p>
           © 
-          2021
+          2022
            edX Inc. All rights reserved.
           <br />
           <span>
@@ -835,7 +835,7 @@ exports[`ProgramListPage renders fetching program error page when there are issu
         </ul>
         <p>
           © 
-          2021
+          2022
            edX Inc. All rights reserved.
           <br />
           <span>


### PR DESCRIPTION
Old Behavior 
- The tabular view was based previously only if the flag `ENABLE_MASTERS_PROGRAM_TAB_VIEW` value is true. 

New Behavior 
- Since for now we only have just two tabs, rendering tabular view in case discussions are not configured feels undesirable. so now tabular view will only be visible if the tabular view flag `ENABLE_MASTERS_PROGRAM_TAB_VIEW` is turned on and discussion is configured for the program.