### PR TITLE
chore: upgrade local docker container to use node v16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copied from https://github.com/BretFisher/node-docker-good-defaults/blob/master/Dockerfile
 
-FROM node:12
+FROM node:16
 
 # Create app directory
 RUN mkdir -p /edx/app


### PR DESCRIPTION
[MST-1435](https://openedx.atlassian.net/browse/MST-1435)
Just want to upgrade the docker image from using node v12 to node v16.
This enables testing on local machine for using node v16 for development, and validating node v16 for stage and prod environment.