### PR TITLE
chore: make sure links point to MFE not legacy

### DIFF
--- a/src/components/course-enrollments/course-cards/BaseCourseCard.jsx
+++ b/src/components/course-enrollments/course-cards/BaseCourseCard.jsx
@@ -237,7 +237,7 @@ class BaseCourseCard extends Component {
           View your certificate on{' '}
           <a
             className="text-underline"
-            href={`${process.env.LMS_BASE_URL}/u/${
+            href={`${process.env.ACCOUNT_PROFILE_URL}/u/${
               getAuthenticatedUser().username
             }`}
           >

--- a/src/components/masters-page/MastersPage.jsx
+++ b/src/components/masters-page/MastersPage.jsx
@@ -28,12 +28,12 @@ function MastersPage({
             },
             {
               type: 'item',
-              href: `${process.env.LMS_BASE_URL}/u/${getAuthenticatedUser().username}`,
+              href: `${process.env.ACCOUNT_PROFILE_URL}/u/${getAuthenticatedUser().username}`,
               content: 'My Profile',
             },
             {
               type: 'item',
-              href: `${process.env.LMS_BASE_URL}/account/settings`,
+              href: process.env.ACCOUNT_SETTINGS_URL,
               content: 'Account Settings',
             },
             {

--- a/src/components/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
+++ b/src/components/programs-list/tests/__snapshots__/ProgramListPage.test.jsx.snap
@@ -391,7 +391,7 @@ exports[`ProgramListPage correctly renders the loading page 1`] = `
           </ul>
           <p>
             © 
-            2024
+            2025
              edX LLC. All rights reserved.
             <br />
             深圳市恒宇博科技有限公司 
@@ -819,7 +819,7 @@ exports[`ProgramListPage renders fetching program error page when there are issu
           </ul>
           <p>
             © 
-            2024
+            2025
              edX LLC. All rights reserved.
             <br />
             深圳市恒宇博科技有限公司 


### PR DESCRIPTION
now that the legacy profile and account pages have been removed, we need to make sure that all of the links point to the MFE URLs; we were relying on the legacy applications to do redirection before.

FIXES: APER-3884
FIXES: openedx/public-engineering#71